### PR TITLE
Replace bytes with bytearray for massive speed up

### DIFF
--- a/pyppd/archiver.py
+++ b/pyppd/archiver.py
@@ -44,7 +44,7 @@ def compress(directory):
     returns a compressed pickle dump of it.
 
     """
-    ppds = b""
+    ppds = bytearray()
     ppds_index = {}
     abs_directory = os.path.abspath(directory)
 


### PR DESCRIPTION
Bytes type is very inefficient for append/concatenation and involves copying the entire data.

This one-line fix speeds up foomatic-db compression from ~20 minutes to 10 seconds.