### PR TITLE
Add unit tests and manual page

### DIFF
--- a/Makefile.tests
+++ b/Makefile.tests
@@ -1,0 +1,15 @@
+# Makefile for testing pyppd
+
+.PHONY: all test clean
+
+all: test
+
+test:
+	@echo "Running pyppd unit tests..."
+	PYTHONPATH=$(PWD) python3 -m unittest discover -s tests
+
+clean:
+	rm -rf *.pyc __pycache__ tests/__pycache__
+	rm -f pyppd-ppdfile
+	rm -f test-output custom-output renamed-archive
+

--- a/pyppd.1
+++ b/pyppd.1
@@ -1,0 +1,112 @@
+.TH PYPPD 1 "April 2025" "pyppd 1.1.1" "CUPS Commands"
+.SH NAME
+pyppd \- CUPS PPD generator and compressor
+.SH SYNOPSIS
+.B pyppd
+[
+.B \-v
+|
+.B \-\-verbose
+] [
+.B \-d
+|
+.B \-\-debug
+] [
+.B \-o
+.I filename
+|
+.B \-\-output=\fIfilename\fR
+]
+.I ppds_directory
+.SH DESCRIPTION
+.B pyppd
+is a CUPS PPD generator that creates a compressed archive of PPD files. It holds a compressed archive of PPDs, which can be listed and retrieved only when needed by CUPS, saving disk space.
+.PP
+At first, you have to create a PPD archive. For such, put all PPDs (they might be gzipped) you want to add in the archive inside a single folder (which can have subfolders), then run:
+.PP
+.B pyppd
+.I /path/to/your/ppd/folder
+.PP
+It'll create
+.B pyppd-ppdfile
+in your current folder. This executable only works with the same Python version that you used to generate it.
+.SH COMMANDS
+The generated
+.B pyppd-ppdfile
+executable supports the following commands:
+.TP 5
+.B list
+List all PPDs in the archive
+.TP 5
+.BI cat " URI"
+Extract the PPD with the given URI from the archive
+.SH EXAMPLES
+Create a PPD archive:
+.PP
+.B pyppd
+.I /usr/share/ppd
+.PP
+List the PPDs in the archive:
+.PP
+.B ./pyppd-ppdfile list
+.PP
+Extract a specific PPD from the archive:
+.PP
+.B ./pyppd-ppdfile cat pyppd-ppdfile:printer/model.ppd
+.PP
+Rename the archive for specialized use:
+.PP
+.B mv pyppd-ppdfile laserjet
+.br
+.B ./laserjet list
+.SH OPTIONS
+.TP 5
+.B \-v, \-\-verbose
+Increase verbosity level. Can be supplied multiple times to increase verbosity further.
+.TP 5
+.B \-d, \-\-debug
+Print debug messages (equivalent to maximum verbosity).
+.TP 5
+.BI \-o " filename" , \-\-output= filename
+Write archive to
+.I filename
+instead of the default
+.B pyppd-ppdfile
+.SH FILES
+.TP 5
+.I /usr/lib/cups/driver/pyppd-ppdfile
+The PPD archive file used by CUPS
+.SH REQUIREMENTS
+.B pyppd
+requires Python 3.x and XZ Utils (http://tukaani.org/xz/).
+.SH SEE ALSO
+.BR cups (1),
+.BR ppdc (1),
+.BR ppdhtml (1),
+.BR ppdi (1),
+.BR ppdmerge (1),
+.BR ppdpo (1),
+.BR cupsd (8)
+.SH AUTHORS
+Vitor Baptista <vitor@vitorbaptista.com>
+.PP
+Contributors:
+.br
+Till Kamppeter - Original idea, mentoring and feedback
+.br
+Hin-Tak Leung - Technical suggestions
+.br
+Martin Pitt - Python 3 port
+.br
+Flávio Ribeiro and Diógenes Fernandes - Refactorings and Python best practices
+.br
+Didier Raboud - Made archives reproducible
+.br
+Sambhav Dusad - Streaming decompression
+.br
+Google's OSPO - Initial funding at GSoC 2010
+.SH COPYRIGHT
+Copyright \(co 2012-2025 Vitor Baptista.
+.PP
+This program is free software; licensed under the MIT license.
+

--- a/setup.py
+++ b/setup.py
@@ -37,4 +37,8 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Topic :: Printing',
         ],
+        test_suite='tests',
+        data_files=[
+        ('share/man/man1', ['pyppd.1']),
+    ],
 )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Empty file to make the directory a Python package

--- a/tests/test_archiver.py
+++ b/tests/test_archiver.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+import unittest
+import tempfile
+import os
+import shutil
+import base64
+import json
+import pyppd.archiver
+import pyppd.compressor
+
+class TestArchiver(unittest.TestCase):
+    """Test the archiver module functionality."""
+    
+    def setUp(self):
+        """Create a temporary directory with sample PPD files."""
+        # Create a temporary directory
+        self.test_dir = tempfile.mkdtemp()
+        
+        # Create a sample PPD file
+        self.ppd_content = b"""*LanguageVersion: English
+*Manufacturer: "Test Manufacturer"
+*NickName: "Test Printer"
+*ModelName: "Test Model"
+*Product: "(Test Printer)"
+"""
+        self.ppd_file = os.path.join(self.test_dir, "test.ppd")
+        with open(self.ppd_file, "wb") as f:
+            f.write(self.ppd_content)
+        
+        # Create a subdirectory with another PPD file
+        os.makedirs(os.path.join(self.test_dir, "subdir"))
+        self.ppd_file2 = os.path.join(self.test_dir, "subdir", "test2.ppd")
+        with open(self.ppd_file2, "wb") as f:
+            f.write(self.ppd_content)
+    
+    def tearDown(self):
+        """Clean up the temporary directory."""
+        shutil.rmtree(self.test_dir)
+    
+    def test_find_files(self):
+        """Test finding PPD files in a directory."""
+        ppd_files = list(pyppd.archiver.find_files(self.test_dir, ["*.ppd"]))
+        
+        # Check that we found both PPD files
+        self.assertEqual(len(ppd_files), 2)
+        self.assertIn(self.ppd_file, ppd_files)
+        self.assertIn(self.ppd_file2, ppd_files)
+    
+    def test_compress(self):
+        """Test compressing PPD files into an archive."""
+        compressed = pyppd.archiver.compress(self.test_dir)
+        
+        # Check that compression worked
+        self.assertIsNotNone(compressed)
+        
+        # Decompress and check the content
+        decompressed = pyppd.compressor.decompress(compressed)
+        ppds_index = json.loads(decompressed.decode('ASCII'))
+        
+        # Check that the archive contains our PPDs
+        self.assertIn('ARCHIVE', ppds_index)
+        self.assertEqual(len(ppds_index) - 1, 2)  # -1 for the ARCHIVE key
+        
+        # Check PPD URIs
+        uris = [key for key in ppds_index.keys() if key != 'ARCHIVE']
+        expected_uris = ['0/test.ppd', '0/subdir/test2.ppd']
+        for uri in expected_uris:
+            self.assertTrue(any(uri in found_uri for found_uri in uris))
+    
+    def test_archive(self):
+        """Test creating an executable archive."""
+        archive = pyppd.archiver.archive(self.test_dir)
+        
+        # Check that archive creation worked
+        self.assertIsNotNone(archive)
+        
+        # Check that the archive contains the expected components
+        self.assertIn(b"@compressor@", archive)
+        self.assertIn(b"@ppds_compressed_b64@", archive)
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+import unittest
+import tempfile
+import os
+import subprocess
+import shutil
+import sys
+
+class TestCLI(unittest.TestCase):
+    """Test the command-line interface."""
+    
+    def setUp(self):
+        """Create a temporary directory with sample PPD files."""
+        # Create a temporary directory
+        self.test_dir = tempfile.mkdtemp()
+        
+        # Create a sample PPD file
+        self.ppd_content = b"""*LanguageVersion: English
+*Manufacturer: "Test Manufacturer"
+*NickName: "Test Printer"
+*ModelName: "Test Model"
+*Product: "(Test Printer)"
+"""
+        self.ppd_file = os.path.join(self.test_dir, "test.ppd")
+        with open(self.ppd_file, "wb") as f:
+            f.write(self.ppd_content)
+    
+    def tearDown(self):
+        """Clean up temporary files."""
+        shutil.rmtree(self.test_dir)
+        
+        # Remove the generated archive if it exists
+        if os.path.exists("pyppd-ppdfile"):
+            os.unlink("pyppd-ppdfile")
+    
+    def test_cli_basic(self):
+        """Test basic CLI functionality."""
+        # Run the pyppd command
+        result = subprocess.run([sys.executable, "-m", "bin.pyppd", self.test_dir],
+                               check=True, capture_output=True)
+        
+        # Check that the output file was created
+        self.assertTrue(os.path.exists("pyppd-ppdfile"))
+        self.assertTrue(os.access("pyppd-ppdfile", os.X_OK))
+    
+    def test_cli_with_output(self):
+        """Test CLI with custom output file."""
+        output_file = "custom-output"
+        
+        # Run the pyppd command
+        result = subprocess.run([sys.executable, "-m", "bin.pyppd", 
+                               "-o", output_file, self.test_dir],
+                               check=True, capture_output=True)
+        
+        # Check that the output file was created
+        self.assertTrue(os.path.exists(output_file))
+        self.assertTrue(os.access(output_file, os.X_OK))
+        
+        # Clean up the output file
+        os.unlink(output_file)
+    
+    def test_cli_verbose(self):
+        """Test CLI with verbose output."""
+        # Run the pyppd command with verbose flag
+        result = subprocess.run([sys.executable, "-m", "bin.pyppd", 
+                               "-v", self.test_dir],
+                               check=True, capture_output=True)
+        
+        # Check that the output file was created
+        self.assertTrue(os.path.exists("pyppd-ppdfile"))
+        
+        # Check for verbose output
+        self.assertIn(b"Compressing folder", result.stdout)
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/tests/test_compressor.py
+++ b/tests/test_compressor.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+import unittest
+import tempfile
+import os
+import pyppd.compressor
+
+class TestCompressor(unittest.TestCase):
+    """Test the compressor module functionality."""
+    
+    def test_compress_decompress(self):
+        """Test that data can be compressed and decompressed correctly."""
+        test_data = b"Hello, World! This is test data for compression."
+        compressed = pyppd.compressor.compress(test_data)
+        
+        # Check that compression actually happened
+        self.assertLess(len(compressed), len(test_data))
+        
+        # Check that decompression restores the original data
+        decompressed = pyppd.compressor.decompress(compressed)
+        self.assertEqual(test_data, decompressed)
+    
+    def test_compress_file(self):
+        """Test that a file can be compressed correctly."""
+        test_data = b"This is test data for file compression."
+        
+        # Create a temporary file
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(test_data)
+            filename = f.name
+        
+        try:
+            # Compress the file
+            compressed = pyppd.compressor.compress_file(filename)
+            
+            # Check that compression actually happened
+            self.assertIsNotNone(compressed)
+            self.assertLess(len(compressed), len(test_data))
+            
+            # Check that the compressed data can be decompressed
+            decompressed = pyppd.compressor.decompress(compressed)
+            self.assertEqual(test_data, decompressed)
+        finally:
+            os.unlink(filename)
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+import unittest
+import tempfile
+import os
+import subprocess
+import shutil
+import sys
+
+class TestIntegration(unittest.TestCase):
+    """Test the full integration workflow."""
+    
+    def setUp(self):
+        """Create a temporary directory with sample PPD files."""
+        # Create a temporary directory
+        self.test_dir = tempfile.mkdtemp()
+        
+        # Create a sample PPD file
+        self.ppd_content = b"""*LanguageVersion: English
+*Manufacturer: "Test Manufacturer"
+*NickName: "Test Printer"
+*ModelName: "Test Model"
+*Product: "(Test Printer)"
+"""
+        self.ppd_file = os.path.join(self.test_dir, "test.ppd")
+        with open(self.ppd_file, "wb") as f:
+            f.write(self.ppd_content)
+    
+    def tearDown(self):
+        """Clean up temporary files."""
+        shutil.rmtree(self.test_dir)
+        
+        # Remove the generated archive if it exists
+        if os.path.exists("pyppd-ppdfile"):
+            os.unlink("pyppd-ppdfile")
+    
+    def test_full_workflow(self):
+        """Test the full workflow from creation to extraction."""
+        # Create the archive
+        subprocess.run([sys.executable, "-m", "bin.pyppd", self.test_dir],
+                      check=True, capture_output=True)
+        
+        # Check that the archive was created
+        self.assertTrue(os.path.exists("pyppd-ppdfile"))
+        self.assertTrue(os.access("pyppd-ppdfile", os.X_OK))
+        
+        # List the PPDs in the archive
+        list_result = subprocess.run(["./pyppd-ppdfile", "list"],
+                                    check=True, capture_output=True)
+        self.assertIn(b"pyppd-ppdfile:test.ppd", list_result.stdout)
+        
+        # Extract a PPD from the archive
+        cat_result = subprocess.run(["./pyppd-ppdfile", "cat", "pyppd-ppdfile:test.ppd"],
+                                   check=True, capture_output=True)
+        self.assertEqual(cat_result.stdout, self.ppd_content)
+    
+    def test_rename_workflow(self):
+        """Test renaming the archive and using it."""
+        # Create the archive
+        subprocess.run([sys.executable, "-m", "bin.pyppd", self.test_dir],
+                      check=True, capture_output=True)
+        
+        # Rename the archive
+        os.rename("pyppd-ppdfile", "renamed-archive")
+        
+        # List the PPDs in the renamed archive
+        list_result = subprocess.run(["./renamed-archive", "list"],
+                                    check=True, capture_output=True)
+        self.assertIn(b"renamed-archive:test.ppd", list_result.stdout)
+        
+        # Extract a PPD from the renamed archive
+        cat_result = subprocess.run(["./renamed-archive", "cat", "renamed-archive:test.ppd"],
+                                   check=True, capture_output=True)
+        self.assertEqual(cat_result.stdout, self.ppd_content)
+        
+        # Clean up the renamed archive
+        os.unlink("renamed-archive")
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/tests/test_ppd.py
+++ b/tests/test_ppd.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+import unittest
+import tempfile
+import os
+import pyppd.ppd
+
+class TestPPD(unittest.TestCase):
+    """Test the PPD parsing functionality."""
+    
+    def test_parse_basic_ppd(self):
+        """Test parsing of a basic PPD file."""
+        ppd_content = b"""*LanguageVersion: English
+*Manufacturer: "Test Manufacturer"
+*NickName: "Test Printer"
+*ModelName: "Test Model"
+*Product: "(Test Printer)"
+"""
+        filename = "test.ppd"
+        parsed = pyppd.ppd.parse(ppd_content, filename)
+        
+        # Check that we got one PPD
+        self.assertEqual(len(parsed), 1)
+        
+        # Check that the PPD has the correct attributes
+        ppd = parsed[0]
+        self.assertEqual(ppd.uri, "0/test.ppd")
+        self.assertEqual(ppd.language, "en")
+        self.assertEqual(ppd.manufacturer, "Test Manufacturer")
+        self.assertEqual(ppd.nickname, "Test Printer")
+    
+    def test_parse_ppd_with_device_id(self):
+        """Test parsing of a PPD file with a device ID."""
+        ppd_content = b"""*LanguageVersion: English
+*Manufacturer: "Test Manufacturer"
+*NickName: "Test Printer"
+*ModelName: "Test Model"
+*1284DeviceID: "MFG:Test Manufacturer;MDL:Test Printer;"
+"""
+        filename = "test.ppd"
+        parsed = pyppd.ppd.parse(ppd_content, filename)
+        
+        # Check that we got one PPD
+        self.assertEqual(len(parsed), 1)
+        
+        # Check that the PPD has the correct attributes
+        ppd = parsed[0]
+        self.assertEqual(ppd.deviceid, "MFG:Test Manufacturer;MDL:Test Printer;")
+    
+    def test_parse_ppd_with_multiple_products(self):
+        """Test parsing of a PPD file with multiple products."""
+        ppd_content = b"""*LanguageVersion: English
+*Manufacturer: "Test Manufacturer"
+*NickName: "Test Printer"
+*ModelName: "Test Model"
+*Product: "(Test Printer 1)"
+*Product: "(Test Printer 2)"
+"""
+        filename = "test.ppd"
+        parsed = pyppd.ppd.parse(ppd_content, filename)
+        
+        # Check that we got two PPDs
+        self.assertEqual(len(parsed), 2)
+        
+        # Check that the PPDs have the correct attributes
+        self.assertEqual(parsed[0].uri, "0/test.ppd")
+        self.assertEqual(parsed[1].uri, "1/test.ppd")
+    
+    def test_parse_gzipped_ppd(self):
+        """Test parsing of a gzipped PPD file."""
+        import gzip
+        
+        ppd_content = b"""*LanguageVersion: English
+*Manufacturer: "Test Manufacturer"
+*NickName: "Test Printer"
+*ModelName: "Test Model"
+*Product: "(Test Printer)"
+"""
+        # Create a temporary gzipped file
+        with tempfile.NamedTemporaryFile(suffix='.ppd.gz', delete=False) as f:
+            with gzip.open(f.name, 'wb') as gz:
+                gz.write(ppd_content)
+            filename = f.name
+        
+        try:
+            # Load the file and parse it
+            with gzip.open(filename, 'rb') as gz:
+                content = gz.read()
+            
+            parsed = pyppd.ppd.parse(content, os.path.basename(filename)[:-3])
+            
+            # Check that we got one PPD
+            self.assertEqual(len(parsed), 1)
+            
+            # Check that the PPD has the correct attributes
+            ppd = parsed[0]
+            self.assertEqual(ppd.manufacturer, "Test Manufacturer")
+            self.assertEqual(ppd.nickname, "Test Printer")
+        finally:
+            os.unlink(filename)
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+import unittest
+import tempfile
+import os
+import sys
+import shutil
+from io import StringIO
+import pyppd.runner
+
+class TestRunner(unittest.TestCase):
+    """Test the runner module functionality."""
+    
+    def setUp(self):
+        """Create a temporary directory with sample PPD files."""
+        # Create a temporary directory
+        self.test_dir = tempfile.mkdtemp()
+        
+        # Create a sample PPD file
+        self.ppd_content = b"""*LanguageVersion: English
+*Manufacturer: "Test Manufacturer"
+*NickName: "Test Printer"
+*ModelName: "Test Model"
+*Product: "(Test Printer)"
+"""
+        self.ppd_file = os.path.join(self.test_dir, "test.ppd")
+        with open(self.ppd_file, "wb") as f:
+            f.write(self.ppd_content)
+        
+        # Save original stdout and argv
+        self.original_stdout = sys.stdout
+        self.original_argv = sys.argv
+        
+        # Redirect stdout to capture output
+        sys.stdout = StringIO()
+    
+    def tearDown(self):
+        """Clean up temporary files and restore stdout."""
+        shutil.rmtree(self.test_dir)
+        
+        # Restore stdout and argv
+        sys.stdout = self.original_stdout
+        sys.argv = self.original_argv
+        
+        # Remove the generated archive if it exists
+        if os.path.exists("pyppd-ppdfile"):
+            os.unlink("pyppd-ppdfile")
+    
+    def test_parse_args(self):
+        """Test command-line argument parsing."""
+        sys.argv = ['pyppd', self.test_dir]
+        options, args = pyppd.runner.parse_args()
+        
+        # Check that the arguments were parsed correctly
+        self.assertEqual(args[0], self.test_dir)
+        self.assertEqual(options.output, "pyppd-ppdfile")
+    
+    def test_parse_args_with_output(self):
+        """Test command-line argument parsing with output option."""
+        output_file = "test-output"
+        sys.argv = ['pyppd', '-o', output_file, self.test_dir]
+        options, args = pyppd.runner.parse_args()
+        
+        # Check that the arguments were parsed correctly
+        self.assertEqual(args[0], self.test_dir)
+        self.assertEqual(options.output, output_file)
+    
+    def test_run(self):
+        """Test running the command."""
+        sys.argv = ['pyppd', '-o', 'test-output', self.test_dir]
+        
+        # Run the command
+        pyppd.runner.run()
+        
+        # Check that the output file was created
+        self.assertTrue(os.path.exists('test-output'))
+        
+        # Clean up the output file
+        os.unlink('test-output')
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
This PR addresses two issues:
1. Adds comprehensive unit tests for all modules
2. Adds a manual page for the pyppd command

The tests cover compression, PPD parsing, archiving, CLI interface, and full workflow integration testing.
The manual page follows standard man page format and describes all available options.
